### PR TITLE
Fix directory name in getTestCaseFromProblemUrl

### DIFF
--- a/script.js
+++ b/script.js
@@ -40,7 +40,7 @@ let getTestCaseFromProblemHtml = (dir, html) => {
 }
 
 function getTestCaseFromProblemUrl(url) {
-  var dir = `./${url[url.length-1]}`;
+  var dir = `./${url.substring(url.lastIndexOf('/')+1)}`;
 
   if (!fs.existsSync(dir)){
       fs.mkdirSync(dir);


### PR DESCRIPTION
Currently, only the last character is taken.
This creates a problem for tasks like https://codeforces.com/contest/1326/problem/D2. Moreover, when there are two tasks with same ending, for eg, D2 and E2, this is more disastrous.