### PR TITLE
Passing the link as a argument(More OSs support)

### DIFF
--- a/script.js
+++ b/script.js
@@ -71,7 +71,7 @@ let getTotalProblemsFromContestHtml = (html) => {
   });
 }
 
-axios.get(process.env.CF_CONTEST)
+axios.get(`${process.argv.slice(2)}`)
     .then(response => {
       // console.log(response);
       getTotalProblemsFromContestHtml(response.data);


### PR DESCRIPTION
Updated the function on line 74 to provide the contest link as a command-line argument. To execute we can just write node script.js https://codeforces.com/contest/1360